### PR TITLE
extend to stream results

### DIFF
--- a/src/Presentation.js
+++ b/src/Presentation.js
@@ -43,7 +43,7 @@ export default class Presentation {
     }
 
     /**
-     * 
+     *
      */
     async streamAs(stream) {
         let newZip = JSZip();
@@ -52,12 +52,21 @@ export default class Presentation {
             if (this.contents[key]) newZip.file(key, this.contents[key]);
             else console.error('No content', key);
         }
-
         await generateNodeStreamAsync(stream, newZip);
     }
 
+    async generateBlob(){
+        let newZip = JSZip();
+
+        for (let key in this.contents) {
+            if (this.contents[key]) newZip.file(key, this.contents[key]);
+            else console.error('No content', key);
+        }
+        await generateNodeStreamAsync({type:"blob"},newZip);
+    }
+
     /**
-     * 
+     *
      */
     async saveAs(file) {
         await this.streamAs(fs.createWriteStream(file));
@@ -95,7 +104,7 @@ export default class Presentation {
     }
 
     /**
-     * 
+     *
      */
     async generate(slides) {
         let newPresentation = this.clone();

--- a/src/Presentation.js
+++ b/src/Presentation.js
@@ -55,14 +55,14 @@ export default class Presentation {
         await generateNodeStreamAsync(stream, newZip);
     }
 
-    async generateBlob(){
+    async generateBlob(btype){
         let newZip = JSZip();
 
         for (let key in this.contents) {
             if (this.contents[key]) newZip.file(key, this.contents[key]);
             else console.error('No content', key);
         }
-        await generateNodeStreamAsync({type:"blob"},newZip);
+        return newZip.generateAsync({type:btype});
     }
 
     /**


### PR DESCRIPTION
I needed to stream resulting pptx back to the client without saving to the server. Using a memory stream (various npm modules that claimed compatibility with file stream) failed so I added a function to create the buffer according to jszip docs.
